### PR TITLE
channels should now inherit permissions

### DIFF
--- a/LuminateDiscordBot/Components.cs
+++ b/LuminateDiscordBot/Components.cs
@@ -71,8 +71,9 @@ namespace LuminateDiscordBot
             ComponentBuilder components = new ComponentBuilder();
             components.WithButton("Close this ticket", $"ticket-close:{channel.Id}", ButtonStyle.Danger);
 
-            channel.SendMessageAsync($"<@&{Utils.RoleConfig["ticket_role"]}>", false, Responses.TicketInitMessage(ticket?.TicketTopic, modal.Reason, Context.Interaction.User.Id), components: components.Build());
+
             await RespondAsync("", new[] { embed.Build() }, ephemeral: true);
+            await channel.SendMessageAsync($"<@&{Utils.RoleConfig["ticket_role"]}>", false, Responses.TicketInitMessage(ticket!.TicketTopic, modal.Reason, Context.Interaction.User.Id), components: components.Build());
 
         }
 

--- a/LuminateDiscordBot/Program.cs
+++ b/LuminateDiscordBot/Program.cs
@@ -8,7 +8,7 @@ namespace LuminateDiscordBot
 {
     internal class Program
     {
-        public static ServiceProvider? _services;
+        public static ServiceProvider? _services = null;
         public static InteractionService? _interactionService;
         public static DiscordSocketClient? client;
         

--- a/LuminateDiscordBot/Utils.cs
+++ b/LuminateDiscordBot/Utils.cs
@@ -44,7 +44,7 @@ namespace LuminateDiscordBot
             ITextChannel channel = await interaction.Context.Guild.CreateTextChannelAsync(Guid.NewGuid().ToString(), c => c.CategoryId = Utils.ChannelConfig["ticket_category"]);
             await channel.AddPermissionOverwriteAsync(interaction.Context.Guild.EveryoneRole, OverwritePermissions.DenyAll(channel));
             await channel.AddPermissionOverwriteAsync(interaction.Context.Guild.GetRole(Utils.RoleConfig["ticket_role"]), OverwritePermissions.AllowAll(channel));
-            await channel.AddPermissionOverwriteAsync(interaction.Context.User, OverwritePermissions.AllowAll(channel));
+            await channel.AddPermissionOverwriteAsync(interaction.Context.User, OverwritePermissions.InheritAll);
             return channel;
         }
     }


### PR DESCRIPTION
[ # ] Utils.CreateTicketChannel(InteractionModuleBase) will no longer grant all permissions to a user, but rather inherit it from the category / user permissions